### PR TITLE
jtag: set output-enable for all bytes.

### DIFF
--- a/jtag-virtual.c
+++ b/jtag-virtual.c
@@ -103,9 +103,6 @@ int jtag_open_virtual_device(unsigned iid) {
 	vir_width_addr = needbits(hub_nodecount);
 	vir_width = vir_width_ir + vir_width_addr;
 
-	fprintf(stderr,"HUB:    Mfg=0x%03x, Ver=0x%02x, Nodes=%d, VIR=%d+%d bits\n",
-		hub_mfg, hub_version, hub_nodecount, vir_width_addr, vir_width_ir);
-
 	for (n = 0; n < hub_nodecount; n++) {
 		unsigned node_ver, node_id, node_mfg, node_iid;
 		if ((r = jtag_dr_8x4(&bits)) < 0) return r;
@@ -113,9 +110,6 @@ int jtag_open_virtual_device(unsigned iid) {
 		node_id = (bits >> 19) & 0xFF;
 		node_mfg = (bits >> 8) & 0x7FF;
 		node_iid = bits & 0xFF;
-
-		fprintf(stderr,"NODE:   Mfg=0x%03x, Ver=0x%02x, ID=0x%02x, IID=0x%02x\n",
-			node_mfg, node_ver, node_id, node_iid);
 
 		if ((node_id == 0x08) && (node_iid) == iid) {
 			vir_addr = (n + 1) << vir_width_ir;

--- a/jtag.c
+++ b/jtag.c
@@ -90,6 +90,11 @@ static int usb_bulk(unsigned char ep, void *data, int len, unsigned timeout) {
 /* bytecount for data bytes that follow in byte mode */
 #define UB_COUNT(n)	((n) & 0x3F)
 
+static inline uint8_t ub(uint8_t flags)
+{
+    return UB_OE | flags;
+}
+
 int jtag_move(int count, unsigned bits){
 	unsigned char buf[64];
 	int n = 0;
@@ -98,11 +103,11 @@ int jtag_move(int count, unsigned bits){
 #endif
 	while (count-- > 0) {
 		if (bits & 1) {
-			buf[n++] = UB_TMS;
-			buf[n++] = UB_TMS | UB_TCK;
+			buf[n++] = ub(UB_TMS);
+			buf[n++] = ub(UB_TMS | UB_TCK);
 		} else {
-			buf[n++] = 0;
-			buf[n++] = UB_TCK;
+			buf[n++] = ub(0);
+			buf[n++] = ub(UB_TCK);
 		}
 		bits >>= 1;
 	}
@@ -120,11 +125,11 @@ int jtag_shift(int count, unsigned bits, unsigned *out) {
 #endif
 	while (count-- > 0) {
 		if (bits & 1) {
-			buf[n++] = UB_TDI;
-			buf[n++] = UB_TDI | UB_TCK | RB;
+			buf[n++] = ub(UB_TDI);
+			buf[n++] = ub(UB_TDI | UB_TCK | RB);
 		} else {
-			buf[n++] = 0;
-			buf[n++] = UB_TCK | RB;
+			buf[n++] = ub(0);
+			buf[n++] = ub(UB_TCK | RB);
 		}
 		bits >>= 1;
 	}


### PR DESCRIPTION
The official Altera blasters ignore this but the cheap clones require it
otherwise everything reads back as zero.

Fixes #1

Signed-off-by: Jamie Iles <jamie@jamieiles.com>